### PR TITLE
Remove patch level from gem dependencies

### DIFF
--- a/hanami-bootstrap.gemspec
+++ b/hanami-bootstrap.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "hanami-assets", "~> 0.2.1"
+  spec.add_dependency "hanami-assets", "~> 0.2"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Given that Hanami follows the [Semantic Versioning 2.0.0](http://semver.org), then the gem dependencies should not include the patch level. Currently, we get a conflict in Gemfile and Bundle aborts.
